### PR TITLE
Smoothing along nest boundaries

### DIFF
--- a/propagation/SWALS/examples/nthmp/BP09/BP09.f90
+++ b/propagation/SWALS/examples/nthmp/BP09/BP09.f90
@@ -11,8 +11,12 @@ module local_routines
 
     contains 
 
-    subroutine set_initial_conditions_BP09(domain)            
-        class(domain_type), target, intent(inout):: domain
+    subroutine set_initial_conditions_BP09(domain, all_dx_md)
+        class(domain_type), intent(inout):: domain
+            !! The domain
+        real(dp), intent(in), optional :: all_dx_md(:,:,:)
+            !! Metadata on multidomain grid sizes, used to smooth along multidomain boundaries.
+
         integer(ip):: i, j
         character(len=charlen):: input_elevation(6), input_stage(1)
         real(dp), allocatable:: x(:), y(:)
@@ -74,6 +78,9 @@ module local_routines
         end if
 
         deallocate(x,y, random_uniform)
+
+        ! Smooth near fine-to-coarse boundaries. Must do this BEFORE adjusting the stage to be >= elevation.
+        if(present(all_dx_md)) call domain%smooth_elevation_near_nesting_fine2coarse_boundaries(all_dx_md)
 
         if(domain%timestepping_method /= 'linear') then
             domain%manning_squared = 0.02_dp * 0.02_dp
@@ -147,6 +154,9 @@ program BP09
     !! If using a very high res domain, assume it is dry before this time. 
     !! If not set correctly, expect the wrong answer!
     !real(dp), parameter :: very_high_res_static_before_time = 235.0_dp
+
+    ! Optionally smooth the elevation near fine 2 coarse nesting boundaries.
+    logical, parameter :: smooth_elevation_near_fine2coarse_nesting_boundaries = .false.
 
 
     ! Useful misc variables
@@ -281,10 +291,16 @@ program BP09
 
     ! Set initial conditions
     do j = 1, size(md%domains)
-        call set_initial_conditions_BP09(md%domains(j))
+        if(smooth_elevation_near_fine2coarse_nesting_boundaries) then
+            ! Option with local smoothing of elevation
+            call set_initial_conditions_BP09(md%domains(j), md%all_dx_md)
+        else
+            ! No smoothing
+            call set_initial_conditions_BP09(md%domains(j))
+        end if
     end do
     call md%make_initial_conditions_consistent()
-    
+
     ! For stability in 'null' regions, we set them to 'high land' that should be inactive. 
     call md%set_null_regions_to_dry()
    

--- a/propagation/SWALS/src/shallow_water/global_mod.f90
+++ b/propagation/SWALS/src/shallow_water/global_mod.f90
@@ -43,6 +43,12 @@ real(dp), parameter:: minimum_allowed_depth = 1.0e-05_dp !! Depth at which veloc
 
 real(dp), parameter:: wall_elevation = 1.0e+6_dp !! Walls (e.g. reflective boundary) may be given this elevation
 
+! Values used to denote 'null regions' (parts of the domain that cannot affect the flow) that are conveniently set to dry
+real(dp), parameter :: stage_null = wall_elevation !! Stage in null region
+real(dp), parameter :: elev_null = wall_elevation  !! Elevation in null region
+real(dp), parameter :: uh_null = 0.0_dp , vh_null = 0.0_dp !! Fluxes in null region
+
+
 ! Timestepping
 real(dp), parameter:: maximum_timestep = 1.0e+20_dp !! Default upper limit on the time-step.
 character(len=charlen), parameter:: default_nonlinear_timestepping_method = 'rk2' !! Used in test suite

--- a/propagation/SWALS/src/shallow_water/multidomain_mod.f90
+++ b/propagation/SWALS/src/shallow_water/multidomain_mod.f90
@@ -4238,19 +4238,19 @@ __FILE__
         end do
         call md%make_initial_conditions_consistent
 
-        call md%write_outputs_and_print_statistics
+        !call md%write_outputs_and_print_statistics
 
         ! Apply local smoothing near nesting boundaries
         do j = 1, size(md%domains)
             call md%domains(j)%smooth_elevation_near_nesting_fine2coarse_boundaries(md%all_dx_md, &
                 coarse_side_ncells = coarse_n, fine_side_ncells = fine_n, number_of_9pt_smooths = num_smooth)
         end do
-        call md%write_outputs_and_print_statistics
+        !call md%write_outputs_and_print_statistics
 
         call md%make_initial_conditions_consistent
         call md%set_null_regions_to_dry
 
-        call md%write_outputs_and_print_statistics
+        !call md%write_outputs_and_print_statistics
 
         ! Check if it worked
         passed = .true.

--- a/propagation/SWALS/tests/parallel_tests/README.md
+++ b/propagation/SWALS/tests/parallel_tests/README.md
@@ -18,4 +18,4 @@ which should return `0` if there are no failures. The same approach can be appli
 
     cat outfile.log | grep FAIL | wc -w
 
-and at the time of writing returns `4163`.
+and at the time of writing returns `4215`.

--- a/propagation/SWALS/tests/unit_tests/README.md
+++ b/propagation/SWALS/tests/unit_tests/README.md
@@ -12,13 +12,17 @@ Compile with:
 
 and run with:
 
-    ./unit_tests
+    ./unit_tests > outfile.log
 
 Since the output is a bit verbose, you might use
 
-    ./unit_tests | grep FAIL
+    grep FAIL outfile.log | wc -l
 
-to check just for failures.
+to count failures (should be 0), and 
+
+    grep PASS outfile.log | wc -l
+
+to count passes (383 at the time of writing).
 
 You might want to adjust the preprocessing flags to check that the
 tests still pass with different compilation options.


### PR DESCRIPTION
This adds the capacity to locally smooth elevation along genuine nesting boundaries (i.e. where the grid size changes). There is also a unit test, and example of usage in BP09 (but currently switched off with a parameter).