### PR TITLE
routines to burn values in polygons

### DIFF
--- a/propagation/SWALS/src/util/burn_into_grid_mod.f90
+++ b/propagation/SWALS/src/util/burn_into_grid_mod.f90
@@ -8,11 +8,12 @@ module burn_into_grid_mod
     use logging_mod
     use stop_mod
     use file_io_mod, only: read_csv_into_array
+    use points_in_poly_mod, only: point_in_poly
     implicit none
 
     private
 
-    public test_burn_into_grid_mod, xyz_lines_type
+    public test_burn_into_grid_mod, xyz_lines_type, polygons_values_type, burn_polygon_value_into_grid
 
     type rank2_allocatable_type
         !! Store the xyz values of the linear features we want to burn into the grid
@@ -28,7 +29,61 @@ module burn_into_grid_mod
         procedure :: burn_into_grid => burn_lines_into_grid
     end type
 
+    type polyvalue_type
+        !! Store a polygon and a value
+        character(len=charlen) :: poly_file = ""
+        real(dp), allocatable :: vertices(:,:) !! vertices
+        real(dp) :: poly_value = -HUGE(1.0_dp) !! Value to be burned
+    end type
+
+    type polygons_values_type
+        !! Hold a collection of polygon/value pairs, and enable burning
+        !! the values into a grid at points inside the respective polygons
+        type(polyvalue_type), allocatable :: polyvalue(:)
+        contains
+        procedure :: setup => setup_polygons_values_type_from_csv_and_value
+        procedure :: burn_into_grid => burn_polygons_values_type_into_grid
+    end type
+
     contains
+
+    subroutine setup_polygons_values_type_from_csv_and_value(pvt, polygon_files, polygon_values, skip_header)
+        !! Use a set of polygon_files (each containing x,y vertices in csv format) and associated values
+        !! to setup a polygons_values_type
+        class(polygons_values_type), intent(inout) :: pvt !! The polygons_values_type to be initialised
+        character(len=charlen), intent(in) :: polygon_files(:) !! Array with csv file names containing polygon vertices
+        real(dp), intent(in) :: polygon_values(:) !! Array of the same length as polygon_files, containing their values
+        integer(ip), optional, intent(in) :: skip_header !! How many header rows to skip when reading the polygon files (default 0)?
+
+        integer(ip) :: i, nl, skip_h
+
+        skip_h = 0
+        if(present(skip_header)) skip_h = skip_header
+
+        ! Setup
+        nl = size(polygon_files, kind=ip)
+        if(size(polygon_values) /= nl) then
+            write(log_output_unit, *) 'Error: polygon_files must have the same length as polygon_files'
+            call generic_stop
+        end if
+        allocate(pvt%polyvalue(nl))
+
+        do i = 1, nl
+            ! Setup each polygon/value pair
+            ! Vertices
+            pvt%polyvalue(i)%poly_file = polygon_files(i)
+            call read_csv_into_array(pvt%polyvalue(i)%vertices, polygon_files(i), skip_header=skip_h)
+            ! Value
+            pvt%polyvalue(i)%poly_value = polygon_values(i)
+
+            if(size(pvt%polyvalue(i)%vertices, 1) /= 2) then
+                write(log_output_unit, *) "Error in setup_polygons_values_type_from_csv_and_value: file ", trim(polygon_files(i))
+                write(log_output_unit, *) "does not seem to be a 2 column csv file"
+                call generic_stop
+            end if
+        end do
+
+    end subroutine
 
     subroutine read_xyz_lines_from_csv(xyz_lines, line_files, skip_header)
         !! Read a set of line_files (each containing x,y,z data for a xyz-line in csv format)
@@ -66,7 +121,7 @@ module burn_into_grid_mod
         real(dp), intent(in) :: x(:), y(:), z(:) !! rank-1 arrays with point xyz coordinates
         real(dp), intent(inout) :: grid(:,:) !! rank-2 array with grid values
         real(dp), intent(in) :: lower_left(2), upper_right(2) !! coordinates defining the grid extent
-        character(len=*), optional :: burn_type
+        character(len=*), optional, intent(in) :: burn_type
         !! character controlling when we burn -- either 'point_value' (default, always burn), or 'max' (only burn if z >
         !! grid value) or 'min' (only burn if z < grid_value)
 
@@ -74,12 +129,8 @@ module burn_into_grid_mod
         integer(ip) :: i, i0, j0
         character(len=charlen) :: burnt
 
-        if(present(burn_type)) then
-            burnt = burn_type
-        else
-            burnt = 'point_value'
-        end if
-
+        burnt = 'point_value'
+        if(present(burn_type)) burnt = burn_type
 
         if(size(x, kind=ip) /= size(y, kind=ip) .or. size(x, kind=ip) /= size(z, kind=ip)) then
             write(log_output_unit, *) "Error in burn_xyz_into_grid: x,y, and z must have the same length"
@@ -108,7 +159,7 @@ module burn_into_grid_mod
                 case('min')
                     grid(i0, j0) = min(grid(i0, j0), z(i))
                 case default
-                    write(log_output_unit, *) "Error in burn_xyz_into_grid: unknown value of burn_type"
+                    write(log_output_unit, *) "Error in burn_xyz_into_grid: unknown value of burn_type ", trim(burnt)
                     call generic_stop
                 end select
             end if
@@ -117,15 +168,13 @@ module burn_into_grid_mod
     end subroutine
 
     subroutine burn_line_into_grid(x, y, z, grid, lower_left, upper_right, burn_type)
-        !!
         !! Similar to burn_xyz_into_grid, but interpolates along xyz as required to ensure we don't miss cells even if the
         !! line segments have length >> dx.
         !! Note that the interpolation is a bit hap-hazard (in terms of exactly which interpolation point is hit).
-        !!
         real(dp), intent(in) :: x(:), y(:), z(:) !! Coordinates of the 3D line
         real(dp), intent(inout) :: grid(:,:) !! Grid into which we burn the elevations
         real(dp), intent(in) :: lower_left(2), upper_right(2) !! Coordinates of the grid
-        character(len=*), optional :: burn_type
+        character(len=*), optional, intent(in) :: burn_type
         !! character controlling when we burn -- either 'point_value' (default, always burn), or 'max' (only burn if z >
         !! grid value) or 'min' (only burn if z < grid_value)
 
@@ -134,11 +183,8 @@ module burn_into_grid_mod
         real(force_double) :: n1, n2
         character(len=charlen) :: burnt
 
-        if(present(burn_type)) then
-            burnt = burn_type
-        else
-            burnt = 'point_value'
-        end if
+        burnt = 'point_value'
+        if(present(burn_type))  burnt = burn_type
 
         if(size(x, kind=ip) /= size(y, kind=ip) .or. size(x, kind=ip) /= size(z, kind=ip)) then
             write(log_output_unit, *) "Error in burn_line_into_grid: x,y, and z must have the same length"
@@ -181,29 +227,134 @@ module burn_into_grid_mod
     end subroutine
 
     subroutine burn_lines_into_grid(xyz_lines, grid, lower_left, upper_right, burn_type)
-        !!
         !! Burn a set of xyz lines into a grid, interpolating along the lines as required.
-        !!
         class(xyz_lines_type), intent(in) :: xyz_lines !! The xyz lines to burn into the grid
         real(dp), intent(inout) :: grid(:,:) !! The grid
         real(dp), intent(in) :: lower_left(2), upper_right(2) !! The grid extent
-        character(len=*), optional :: burn_type
+        character(len=*), optional, intent(in) :: burn_type
         !! character controlling when we burn -- either 'point_value' (default, always burn the z value into the grid), or 'max'
         !! (only burn if z > grid value) or 'min' (only burn if z < grid_value)
 
         character(len=charlen) :: burnt
         integer(ip) :: i
 
-        if(present(burn_type)) then
-            burnt = burn_type
-        else
-            burnt = 'point_value'
-        end if
+        burnt = 'point_value'
+        if(present(burn_type)) burnt = burn_type
 
         do i = 1, size(xyz_lines%lines, kind=ip)
             call burn_line_into_grid(&
                 xyz_lines%lines(i)%xyz(1,:), xyz_lines%lines(i)%xyz(2,:), xyz_lines%lines(i)%xyz(3,:), &
                 grid, lower_left, upper_right, burnt)
+        end do
+
+    end subroutine
+
+    subroutine burn_polygon_value_into_grid(poly_x, poly_y, poly_value, grid, lower_left, upper_right, burn_type)
+        !! Set grid points inside the polygon to the poly_value.
+        !! This can be used standalone, but for more convenience
+        !! in the multi-polygon case see polygons_values_type%burn_into_grid
+        real(dp), intent(in) :: poly_x(:), poly_y(:), poly_value !! Polygon vertex coordinates and value to burn
+        real(dp), intent(inout) :: grid(:,:) !! The grid -- first dimension ranges from lower_left(1) to upper_right(1).
+        real(dp), intent(in) :: lower_left(2), upper_right(2) !! The grid extent (coordinate range for each dimension).
+        character(len=*), optional, intent(in) :: burn_type
+        !! character controlling when we burn -- either 'point_value'
+        !! (default, always burn the z value into the grid), or 'max'
+        !! (only burn if z > grid value) or 'min' (only burn if z < grid_value)
+
+        character(len=charlen) :: burnt
+        real(dp) :: x, y, min_x, max_x, min_y, max_y
+        integer :: i, j
+        logical :: is_in_poly
+
+        burnt = 'point_value'
+        if(present(burn_type)) burnt = burn_type
+
+        if(size(poly_x) /= size(poly_y)) then
+            write(log_output_unit, *) "Error in burn_polygon_value_into_grid: unequal lengths of poly_x, poly_y"
+            call generic_stop
+        end if
+
+        if(.not. all(upper_right > lower_left)) then
+            write(log_output_unit, *) "Error in burn_polyvalue_into_grid: upper_right must be > lower_left"
+            call generic_stop
+        end if
+
+        min_x = minval(poly_x)
+        max_x = maxval(poly_x)
+        min_y = minval(poly_y)
+        max_y = maxval(poly_y)
+
+        ! Quick exit if clearly no overlap
+        if(upper_right(2) < min_y .or. lower_left(2) > max_y .or. &
+           upper_right(1) < min_x .or. lower_left(1) > max_x) return
+
+        ! Search each grid point
+        do j = 1, size(grid, 2)
+            ! Get y coord
+            y = lower_left(2) + ((j - 0.5_dp)/size(grid, 2))*(upper_right(2) - lower_left(2))
+            ! Quick exit if possible
+            if(y < min_y .or. y > max_y) cycle
+
+            do i = 1, size(grid, 1)
+                ! Get x coord
+                x = lower_left(1) + ((i - 0.5_dp)/size(grid, 1))*(upper_right(1) - lower_left(1))
+                ! Quick exit if possible
+                if(x < min_x .or. x > max_x) cycle
+
+                ! Determine if x/y is inside
+                call point_in_poly(size(poly_x), poly_x, poly_y, x, y, is_in_poly)
+
+                if(is_in_poly) then
+                    ! Set the value
+                    select case (burnt)
+                    case('point_value')
+                        grid(i,j) = poly_value
+                    case('max')
+                        grid(i, j) = max(grid(i, j), poly_value)
+                    case('min')
+                        grid(i, j) = min(grid(i, j), poly_value)
+                    case default
+                        write(log_output_unit, *) &
+                            "Error in burn_polyvalue_into_grid: unknown value of burn_type ", trim(burnt)
+                        call generic_stop
+                    end select
+                end if
+            end do
+        end do
+
+    end subroutine
+
+    subroutine burn_polygons_values_type_into_grid(pvt, grid, lower_left, upper_right, burn_type)
+        !!
+        !! For all polygon/value pairs in a polygons_values_type, burn the
+        !! value into the grid at points inside the polygon.
+        !!
+        class(polygons_values_type), intent(in) :: pvt
+            !! Holds all polygons and their values
+        real(dp), intent(inout) :: grid(:,:)
+            !! The grid -- first dimension ranges from lower_left(1) to upper_right(1).
+        real(dp), intent(in) :: lower_left(2), upper_right(2)
+            !! The grid extent, i.e. coordinate range for the first and second dimensions.
+        character(len=*), optional, intent(in) :: burn_type
+            !! character controlling when we burn -- either 'point_value'
+            !! (default, always burn the z value into the grid), or 'max'
+            !! (only burn if z > grid value) or 'min' (only burn if z < grid_value)
+
+        integer :: k
+
+        if(.not. allocated(pvt%polyvalue)) then
+            write(log_output_unit, *) 'Error: unallocated polyvalue array '
+            call generic_stop
+        end if
+
+        do k = 1, size(pvt%polyvalue)
+            if(.not. allocated(pvt%polyvalue(k)%vertices)) then
+                write(log_output_unit, *) 'Error: unallocated polygon vertices at pv%polyvalue(', k, ')'
+                call generic_stop
+            end if
+            call burn_polygon_value_into_grid(pvt%polyvalue(k)%vertices(1,:), pvt%polyvalue(k)%vertices(2,:), &
+                pvt%polyvalue(k)%poly_value, &
+                grid, lower_left, upper_right, burn_type)
         end do
 
     end subroutine
@@ -215,8 +366,10 @@ module burn_into_grid_mod
         real(dp) :: x(5), y(5), z(5)
         real(dp) :: expected_grid(10,10)
         real(dp) :: lx(3), ly(3), lz(3)
-        integer(ip) :: i
+        real(dp) :: px(4), py(4), pv
+        integer(ip) :: i, fid
         real(dp), parameter :: eps = 1.0e-03_dp
+        type(polygons_values_type) :: pvt
 
         lower_left = [0.0_dp, 0.0_dp]
         upper_right = [10.0_dp, 10.0_dp]
@@ -295,6 +448,94 @@ module burn_into_grid_mod
         !print*, 'grid(6, 5:10): ', grid(6, 5:10)
         !print*, 'expected_grid(6, 5:10): ', expected_grid(6, 5:10)
 
+        !
+        ! Polygon version, test 1
+        !
+        grid = 0.0_dp
+        px = [3.0_dp, 3.0_dp, 6.0_dp, 4.0_dp]
+        py = [2.0_dp, 5.0_dp, 5.0_dp, 2.0_dp]
+        pv = 1.0_dp
+        call burn_polygon_value_into_grid(px, py, pv, grid, lower_left, upper_right, 'point_value')
+
+        ! Plot this situation to see where the tests below come from.
+        if(abs(sum(grid) - 6.0_dp) < 3*spacing(6.0_dp)) then
+            print*, 'PASS'
+        else
+            print*, 'FAIL'
+        end if
+
+        if(all(grid(4:4, 3:3) == pv) .and. all(grid(4:5, 4) == pv) .and. all(grid(4:6, 5) == pv)) then
+            print*, 'PASS'
+        else
+            print*, 'FAIL'
+        end if
+
+        ! Write the above poly to a file for later testing
+        open(newunit=fid, file='polygon_test_file_1.csv', form='formatted', action='write')
+        write(fid, *) 'lon, lat'
+        do i = 1, size(px)
+            write(fid, *) px(i), ', ', py(i)
+        end do
+        close(fid)
+
+        !
+        ! Polygon version, test 2 -- swap 'px' and 'py'
+        !
+        grid = 0.0_dp
+        py = [3.0_dp, 3.0_dp, 6.0_dp, 4.0_dp]
+        px = [2.0_dp, 5.0_dp, 5.0_dp, 2.0_dp]
+        pv = 1.0_dp
+        call burn_polygon_value_into_grid(px, py, pv, grid, lower_left, upper_right, 'point_value')
+
+        ! Plot this situation to see where the tests below come from.
+        if(abs(sum(grid) - 6.0_dp) < 3*spacing(6.0_dp)) then
+            print*, 'PASS'
+        else
+            print*, 'FAIL'
+        end if
+
+        if(all(grid(3:3, 4:4) == pv) .and. all(grid(4, 4:5) == pv) .and. all(grid(5, 4:6) == pv)) then
+            print*, 'PASS'
+        else
+            print*, 'FAIL'
+        end if
+        
+        ! Write the above poly to a file for later testing
+        open(newunit=fid, file='polygon_test_file_2.csv', form='formatted', action='write')
+        write(fid, *) 'lon, lat'
+        do i = 1, size(px)
+            write(fid, *) px(i), ', ', py(i)
+        end do
+        close(fid)
+        
+        !
+        ! Polygon version, test 3 -- use the polygons_values_type with 2 polygons
+        !
+        call pvt%setup([character(len=charlen) :: 'polygon_test_file_1.csv', 'polygon_test_file_2.csv'], &
+                       [2.0_dp, 1.0_dp], skip_header=1_ip)
+        grid = 0.0_dp
+        call pvt%burn_into_grid(grid, lower_left, upper_right, burn_type='max') 
+
+        ! Plot this situation to see where the tests below come from.
+        if(abs(sum(grid) - 14.0_dp) < 3*spacing(14.0_dp)) then
+            print*, 'PASS'
+        else
+            print*, 'FAIL'
+        end if
+
+        ! Sites covered by polygon 1 should have the value 2
+        if(all(grid(4:4, 3:3) == 2.0_dp) .and. all(grid(4:5, 4) == 2.0_dp) .and. all(grid(4:6, 5) == 2.0_dp)) then
+            print*, 'PASS'
+        else
+            print*, 'FAIL'
+        end if
+        ! Since there is overlap of polygon 1 and 2, only these grid values should be 1.0
+        if(grid(3,4) == 1.0_dp .and. grid(5,6) == 1.0_dp) then
+            print*, 'PASS'
+        else
+            print*, 'FAIL'
+        end if
+        
     end subroutine
 
 end module


### PR DESCRIPTION
Useful to be able to burn values into a polygon. This provides a procedural and an object-based interface to do that, the latter being simpler in the case of multiple polygons stored in csv files.