### PR TITLE
Clean examples

### DIFF
--- a/misc/SW_WA_2021_2024/greater_perth_revised2023/analysis/check_log_files/check_log_files.R
+++ b/misc/SW_WA_2021_2024/greater_perth_revised2023/analysis/check_log_files/check_log_files.R
@@ -229,7 +229,7 @@ stopifnot(is.finite(MSL_LINEAR_DEFAULT) & is.finite(EXPECTED_FINAL_TIME))
 
 library(parallel)
 MC_CORES = 1 #48
-check_data = mclapply(all_log_files, f<-function(logfile){
+check_data = mclapply(all_log_files, function(logfile){
     tmp=get_time_energy_stagerange_from_log(logfile, msl_linear = MSL_LINEAR_DEFAULT)
     output = check_log(tmp, expected_final_time=EXPECTED_FINAL_TIME)
     rm(tmp)

--- a/misc/SW_WA_2021_2024/greater_perth_revised2023/analysis/probabilistic_inundation/application_specific_file_metadata.R
+++ b/misc/SW_WA_2021_2024/greater_perth_revised2023/analysis/probabilistic_inundation/application_specific_file_metadata.R
@@ -139,7 +139,7 @@ find_matching_md_data<-function(row_indices, tarred_multidomain_data, source_zon
         substring(as.character(1e+07 + row_indices), 2, 8), '_')
 
     # Match with the tarred_multidomain_data, with NA if we don't match or get multiple matches
-    matching_ind = sapply(matching_string, f<-function(x){
+    matching_ind = sapply(matching_string, function(x){
         p = grep(x, tarred_multidomain_data)
         if(length(p) != 1) p = NA 
         return(p)})

--- a/misc/SW_WA_2021_2024/greater_perth_revised2023/swals/model_initial_conditions_mod.f90
+++ b/misc/SW_WA_2021_2024/greater_perth_revised2023/swals/model_initial_conditions_mod.f90
@@ -196,7 +196,7 @@ end subroutine
 subroutine set_initial_conditions(domain, stage_file, global_dt, all_dx_md)
     !! Setup initial conditions and earthquake forcing
 
-    class(domain_type), intent(inout):: domain
+    type(domain_type), intent(inout):: domain
         ! We initialise domain%U and domain%manning_squared, and
         ! setup the forcing term if rise_time > 0
     character(len=charlen), intent(in) :: stage_file
@@ -375,7 +375,7 @@ subroutine setup_stage_and_forcing(domain, stage_file, global_dt)
     !! Set the domain's stage in domain%U(:,:,STG). If the rise_time is
     !! greater than zero, then also setup the rise_time forcing.
 
-    class(domain_type), intent(inout):: domain
+    type(domain_type), intent(inout):: domain
         !! This routine sets domain%U(:,:,STG), and may set
         !! domain%forcing_context_cptr and domain%forcing_subroutine
     character(len=charlen), intent(in) :: stage_file
@@ -515,7 +515,7 @@ subroutine setup_forcing_with_rise_time(domain, stage_file, slip, start_time, en
     !! If the stage-perturbation is applied over a non-zero rise-time
     !! (i.e. not instantaneous), then this routine will set up the forcing
     !! terms.
-    class(domain_type), intent(inout):: domain
+    type(domain_type), intent(inout):: domain
         !! If the stage-perturbation affects the doman, then this routine
         !! will append a forcing term to that domain.
     character(len=charlen), intent(in) :: stage_file

--- a/propagation/SWALS/examples/circular_island/circular_island_testcase.f90
+++ b/propagation/SWALS/examples/circular_island/circular_island_testcase.f90
@@ -48,7 +48,7 @@ module local_routines
     subroutine set_initial_conditions_circular_island(domain, offshore_depth, island_radius, slope_radius)
         !! Setup initial conditions + locations of gauges
 
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         real(dp), intent(in) :: offshore_depth, island_radius, slope_radius
 
         ! Local variables
@@ -154,7 +154,7 @@ program circular_island
         ! Single domain model
         allocate(md%domains(1))
         dx = 2000.00_dp/mesh_refine
-        md%domains(1)%lw = [2000.0_dp , 3000.0_dp]*1e+03
+        md%domains(1)%lw = [2000.0_dp , 3000.0_dp]*1e+03_dp
         md%domains(1)%lower_left = -md%domains(1)%lw/2.0_dp
         md%domains(1)%nx = nint(md%domains(1)%lw/dx)
         md%domains(1)%timestepping_method = timestepping_method
@@ -165,7 +165,7 @@ program circular_island
         ! Coarser outer domain
         allocate(md%domains(2))
         dx = 4000.00_dp/mesh_refine
-        md%domains(1)%lw = [2000.0_dp , 3000.0_dp]*1e+03 
+        md%domains(1)%lw = [2000.0_dp , 3000.0_dp]*1e+03_dp 
         md%domains(1)%lower_left = -md%domains(1)%lw/2.0_dp
         md%domains(1)%nx = nint(md%domains(1)%lw/dx)
         md%domains(1)%timestepping_method = timestepping_method

--- a/propagation/SWALS/examples/dambreak/dam_break.f90
+++ b/propagation/SWALS/examples/dambreak/dam_break.f90
@@ -12,7 +12,7 @@ module local_routines
         !!
         !! Initial conditions for the dam-break problem
         !!
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         real(dp), intent(in) :: h_upstream, h_downstream
 
         integer(ip):: i,j

--- a/propagation/SWALS/examples/generic_example/generic_model.f90
+++ b/propagation/SWALS/examples/generic_example/generic_model.f90
@@ -18,7 +18,7 @@ module local_routines
         input_stage_raster, hazard_points_file, skip_header,&
         adaptive_computational_extents, negative_elevation_raster, manning_n, rise_time)
 
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         character(len=charlen), intent(in):: input_elevation_raster, &
             input_stage_raster, hazard_points_file
         integer(ip), intent(in):: skip_header

--- a/propagation/SWALS/examples/isolated_building/model.f90
+++ b/propagation/SWALS/examples/isolated_building/model.f90
@@ -27,7 +27,7 @@ module local_routines
 
     ! Main setup routine
     subroutine set_initial_conditions(domain)
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
 
         integer(ip):: i, j, k, n
         character(len=charlen):: input_elevation, input_stage

--- a/propagation/SWALS/examples/landslide_tsunami/benchmark_problem1.f90
+++ b/propagation/SWALS/examples/landslide_tsunami/benchmark_problem1.f90
@@ -15,7 +15,7 @@ module local_routines
     contains 
 
     subroutine set_initial_conditions(domain, wall_width)
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         real(dp), intent(in) :: wall_width
 
         integer(ip):: i, j, initial_stage_unit, file_header_lines

--- a/propagation/SWALS/examples/merewether/merewether_example.f90
+++ b/propagation/SWALS/examples/merewether/merewether_example.f90
@@ -26,7 +26,7 @@ module local_routines
         !
         ! Initialise the domain elevation, stage, flux, manning roughness, and forcing term
         !
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
 
         integer(ip):: i, j, k, house_file_unit
         real(dp), allocatable:: x(:), y(:)
@@ -175,11 +175,11 @@ program merewether
     real(dp), parameter :: final_time = 900.0_dp
 
     ! Length/width
-    real(dp), parameter, dimension(2):: global_lw = [320.0_dp, 415.0_dp]
+    real(dp), parameter :: global_lw(2) = [320.0_dp, 415.0_dp]
     ! Lower-left corner coordinate
-    real(dp), parameter, dimension(2):: global_ll = [382251.0_dp, 6354266.5_dp]
+    real(dp), parameter :: global_ll(2) = [382251.0_dp, 6354266.5_dp]
     ! grid size (number of x/y cells)
-    integer(ip), parameter, dimension(2):: global_nx = [320_ip, 415_ip] ![160_ip, 208_ip] ![321_ip, 416_ip]
+    integer(ip), parameter :: global_nx(2) = [320_ip, 415_ip] ![160_ip, 208_ip] ![321_ip, 416_ip]
     ! Track mass
     real(force_double) :: volume_added
 

--- a/propagation/SWALS/examples/nesting_plane_wave/nesting_reflection.f90
+++ b/propagation/SWALS/examples/nesting_plane_wave/nesting_reflection.f90
@@ -10,7 +10,7 @@ module local_routines
 
     ! Main setup routine
     subroutine set_initial_conditions(domain)
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
 
         integer(ip):: i, j
         character(len=charlen):: initial_stage
@@ -163,7 +163,7 @@ program nesting_reflection
         md%domains(2)%timestepping_method = ts_method
         
         ! Right domain
-        md%domains(3)%lower_left = [global_ll(1) + global_lw(1)*2.0/3.0, global_ll(2)]
+        md%domains(3)%lower_left = [global_ll(1) + global_lw(1)*2.0_dp/3.0_dp, global_ll(2)]
         md%domains(3)%lw = [global_lw(1)/3.0_dp, global_lw(2)]
         md%domains(3)%nx = nint(md%domains(1)%lw/res_d1)
         md%domains(3)%dx = md%domains(1)%lw/md%domains(1)%nx

--- a/propagation/SWALS/examples/nthmp/BP01/BP1_testcases.f90
+++ b/propagation/SWALS/examples/nthmp/BP01/BP1_testcases.f90
@@ -13,7 +13,7 @@ module local_routines
     contains 
 
     subroutine set_initial_conditions_BP1(domain, d, beach_slope, land_length, sea_length, X0, X1, H, gamma0)
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         real(dp), intent(in) :: d, beach_slope, land_length, sea_length, X0, X1, H, gamma0 
 
         integer(ip) :: i,j, ngauge

--- a/propagation/SWALS/examples/nthmp/BP02_and_BP05/BP2_testcases.f90
+++ b/propagation/SWALS/examples/nthmp/BP02_and_BP05/BP2_testcases.f90
@@ -66,7 +66,7 @@ module local_routines
     end function
 
     subroutine set_initial_conditions_bp2(domain, tank_bases, tank_slopes, tank_width, initial_depth)
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         real(dp), intent(in) :: tank_bases(4), tank_slopes(4), tank_width, initial_depth
 
         real(dp):: tank_x(5)
@@ -150,8 +150,8 @@ program BP02
     character(charlen) :: timestepping_method
     
     ! length/width
-    real(dp), dimension(2) :: global_lw, global_ll
-    integer(ip), dimension(2) :: global_nx 
+    real(dp) :: global_lw(2), global_ll(2)
+    integer(ip) :: global_nx(2) 
 
     ! Local variables 
     real(dp) :: timestep, base_l, dx, tank_width, tank_length, initial_depth

--- a/propagation/SWALS/examples/nthmp/BP04/BP4_testcases.f90
+++ b/propagation/SWALS/examples/nthmp/BP04/BP4_testcases.f90
@@ -9,7 +9,7 @@ module local_routines
     contains 
 
     subroutine set_initial_conditions_BP1(domain, d, beach_slope, land_length, sea_length, X0, X1, H, gamma0)
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         real(dp), intent(in) :: d, beach_slope, land_length, sea_length, X0, X1, H, gamma0 
 
         integer(ip) :: i,j, ngauge

--- a/propagation/SWALS/examples/nthmp/BP06/BP06.f90
+++ b/propagation/SWALS/examples/nthmp/BP06/BP06.f90
@@ -275,7 +275,7 @@ module local_routines
 
     ! Main setup routine
     subroutine set_initial_conditions(domain, forcing_case)
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         integer(ip), intent(in) :: forcing_case
 
         integer(ip):: i, j

--- a/propagation/SWALS/examples/nthmp/BP06/BP06.f90
+++ b/propagation/SWALS/examples/nthmp/BP06/BP06.f90
@@ -393,7 +393,7 @@ program BP06
 
     use global_mod, only: ip, dp, minimum_allowed_depth, default_nonlinear_timestepping_method
     use domain_mod, only: domain_type
-    use multidomain_mod, only: multidomain_type, setup_multidomain, test_multidomain_mod
+    use multidomain_mod, only: multidomain_type
     use boundary_mod, only: flather_boundary, transmissive_boundary
     use timer_mod, only: timer_type
     use logging_mod, only: log_output_unit

--- a/propagation/SWALS/examples/nthmp/BP07/monai.f90
+++ b/propagation/SWALS/examples/nthmp/BP07/monai.f90
@@ -84,13 +84,12 @@ module local_routines
 
     ! Main setup routine
     subroutine set_initial_conditions(domain)
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         integer(ip):: i, j
         character(len=charlen):: input_elevation, input_stage
         real(dp), allocatable:: x(:), y(:)
         type(multi_raster_type):: elevation_data
-        real(dp) :: wall
-        real(dp) :: gauge_xy(3,3)
+        real(dp) :: wall, gauge_xy(3,3)
 
         ! Stage
         domain%U(:,:,STG) = 0.0e-0_dp
@@ -119,7 +118,7 @@ module local_routines
         domain%U(:,domain%nx(2),ELV) = wall
         domain%U(domain%nx(1),:,ELV) = wall
 
-        if(domain%timestepping_method /= 'linear') then
+        if(allocated(domain%manning_squared)) then
             domain%manning_squared = 0.01_dp * 0.01_dp
         end if
 

--- a/propagation/SWALS/examples/nthmp/BP07/monai.f90
+++ b/propagation/SWALS/examples/nthmp/BP07/monai.f90
@@ -144,7 +144,7 @@ program BP07
 
     use global_mod, only: ip, dp, minimum_allowed_depth, default_nonlinear_timestepping_method
     use domain_mod, only: domain_type
-    use multidomain_mod, only: multidomain_type, setup_multidomain, test_multidomain_mod
+    use multidomain_mod, only: multidomain_type
     use boundary_mod, only: boundary_stage_transmissive_normal_momentum
     use local_routines
     use timer_mod

--- a/propagation/SWALS/examples/nthmp/BP09/BP09.f90
+++ b/propagation/SWALS/examples/nthmp/BP09/BP09.f90
@@ -12,7 +12,7 @@ module local_routines
     contains 
 
     subroutine set_initial_conditions_BP09(domain, all_dx_md)
-        class(domain_type), intent(inout):: domain
+        type(domain_type), intent(inout):: domain
             !! The domain
         real(dp), intent(in), optional :: all_dx_md(:,:,:)
             !! Metadata on multidomain grid sizes, used to smooth along multidomain boundaries.
@@ -83,7 +83,7 @@ module local_routines
         ! Smooth near fine-to-coarse boundaries. Must do this BEFORE adjusting the stage to be >= elevation.
         if(present(all_dx_md)) call domain%smooth_elevation_near_nesting_fine2coarse_boundaries(all_dx_md)
 
-        if(domain%timestepping_method /= 'linear') then
+        if(allocated(domain%manning_squared)) then
             domain%manning_squared = 0.02_dp * 0.02_dp
         else
             ! Clip depths in linear solver, to avoid 'stage below the bed'

--- a/propagation/SWALS/examples/nthmp/BP09/BP09.f90
+++ b/propagation/SWALS/examples/nthmp/BP09/BP09.f90
@@ -83,10 +83,10 @@ module local_routines
         ! Smooth near fine-to-coarse boundaries. Must do this BEFORE adjusting the stage to be >= elevation.
         if(present(all_dx_md)) call domain%smooth_elevation_near_nesting_fine2coarse_boundaries(all_dx_md)
 
-        if(allocated(domain%manning_squared)) then
+        if(domain%timestepping_method /= 'linear') then
             domain%manning_squared = 0.02_dp * 0.02_dp
         else
-            ! Clip depths in linear solver, to avoid 'stage below the bed'
+            ! Avoid very shallow depths below MSL in linear solver
             where(domain%U(:,:,ELV) < 0.0_dp .and. domain%U(:,:,ELV) > -5.0_dp) domain%U(:,:,ELV) = -5.0_dp
         end if
 

--- a/propagation/SWALS/examples/nthmp/Conical_shelf_lab/model.f90
+++ b/propagation/SWALS/examples/nthmp/Conical_shelf_lab/model.f90
@@ -87,7 +87,7 @@ program Conical_shelf
     !!
 
     use global_mod, only: ip, dp, minimum_allowed_depth, default_nonlinear_timestepping_method
-    use multidomain_mod, only: multidomain_type, setup_multidomain
+    use multidomain_mod, only: multidomain_type
     use boundary_mod, only: flather_boundary
     use timer_mod, only: timer_type
     use logging_mod, only: log_output_unit

--- a/propagation/SWALS/examples/nthmp/Conical_shelf_lab/model.f90
+++ b/propagation/SWALS/examples/nthmp/Conical_shelf_lab/model.f90
@@ -23,7 +23,7 @@ module local_routines
 
     ! Main geometry setup routine
     subroutine set_initial_conditions(domain)
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
 
         type(multi_raster_type):: elevation_data
         real(dp), allocatable:: x(:), y(:)
@@ -139,7 +139,7 @@ program Conical_shelf
         call set_initial_conditions(md%domains(j))
     end do
 
-    ! FIXME: Add point gauges
+    ! Add point gauges
     call md%set_point_gauges_from_csv('point_gauge_locations.csv', skip_header=1_ip)
 
     ! Boundary conditions

--- a/propagation/SWALS/examples/nthmp/Hilo_Tohoku_tsunami/model.f90
+++ b/propagation/SWALS/examples/nthmp/Hilo_Tohoku_tsunami/model.f90
@@ -185,7 +185,7 @@ program Hilo_harbour_Tohoku
     use global_mod, only: ip, dp, minimum_allowed_depth, &
         default_nonlinear_timestepping_method
     use domain_mod, only: domain_type
-    use multidomain_mod, only: multidomain_type, setup_multidomain
+    use multidomain_mod, only: multidomain_type
     use boundary_mod, only: flather_boundary, boundary_stage_radiation_momentum
     use local_routines
     use timer_mod

--- a/propagation/SWALS/examples/nthmp/Hilo_Tohoku_tsunami/model.f90
+++ b/propagation/SWALS/examples/nthmp/Hilo_Tohoku_tsunami/model.f90
@@ -123,7 +123,7 @@ module local_routines
 
     ! Main setup routine
     subroutine set_initial_conditions(domain)
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         integer(ip):: j
         character(len=charlen):: input_elevation, input_stage
         real(dp), allocatable:: x(:), y(:)

--- a/propagation/SWALS/examples/nthmp/Seaside_OSU_model/model.f90
+++ b/propagation/SWALS/examples/nthmp/Seaside_OSU_model/model.f90
@@ -205,7 +205,7 @@ program Seaside_OSU
 
     use global_mod, only: ip, dp, minimum_allowed_depth, &
         default_nonlinear_timestepping_method
-    use multidomain_mod, only: multidomain_type, setup_multidomain
+    use multidomain_mod, only: multidomain_type
     use boundary_mod, only: boundary_stage_transmissive_normal_momentum, boundary_stage_radiation_momentum, flather_boundary
     use timer_mod, only: timer_type
     use logging_mod, only: log_output_unit

--- a/propagation/SWALS/examples/nthmp/Seaside_OSU_model/model.f90
+++ b/propagation/SWALS/examples/nthmp/Seaside_OSU_model/model.f90
@@ -136,7 +136,7 @@ module local_routines
    
     ! Main geometry setup routine
     subroutine set_initial_conditions(domain)
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
 
         type(multi_raster_type):: elevation_data
         real(dp), allocatable:: x(:), y(:)

--- a/propagation/SWALS/examples/nthmp/Submerged_Island_Lab/model.f90
+++ b/propagation/SWALS/examples/nthmp/Submerged_Island_Lab/model.f90
@@ -136,7 +136,7 @@ program Submerged_Island
 
     use global_mod, only: ip, dp, minimum_allowed_depth, default_nonlinear_timestepping_method
     use domain_mod, only: domain_type
-    use multidomain_mod, only: multidomain_type, setup_multidomain, test_multidomain_mod
+    use multidomain_mod, only: multidomain_type
     use boundary_mod, only: flather_boundary
     use timer_mod
     use logging_mod, only: log_output_unit

--- a/propagation/SWALS/examples/nthmp/Submerged_Island_Lab/model.f90
+++ b/propagation/SWALS/examples/nthmp/Submerged_Island_Lab/model.f90
@@ -42,13 +42,11 @@ module local_routines
 
     ! Main setup routine
     subroutine set_initial_conditions(domain)
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
 
         integer(ip):: i, j
         real(dp), allocatable:: x(:), y(:)
-        real(dp) :: gauges_1_to_4_x_coord, dd
-        real(dp) :: gauge_xy(3,2)
-        
+        real(dp) :: gauges_1_to_4_x_coord, dd, gauge_xy(3,2)
 
         ! Stage
         domain%U(:,:,STG) = 0.0e-0_dp

--- a/propagation/SWALS/examples/nthmp/Tauranga_harbour_Tohoku_tsunami/tauranga.f90
+++ b/propagation/SWALS/examples/nthmp/Tauranga_harbour_Tohoku_tsunami/tauranga.f90
@@ -153,15 +153,13 @@ module local_routines
 
     ! Main setup routine
     subroutine set_initial_conditions(domain)
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         integer(ip):: i, j
         character(len=charlen):: input_elevation, input_stage
         real(dp), allocatable:: x(:), y(:)
         logical, allocatable:: is_inside(:)
         type(multi_raster_type):: elevation_data
-        real(dp) :: wall, w
-        real(dp) :: gauge_xy(3,6)
-        real(dp) :: pol1(4,2), pol2(4,2)
+        real(dp) :: wall, gauge_xy(3,6), pol1(4,2), pol2(4,2)
         logical :: flatten_bathymetry_near_boundary
 
         ! Stage

--- a/propagation/SWALS/examples/nthmp/Tauranga_harbour_Tohoku_tsunami/tauranga.f90
+++ b/propagation/SWALS/examples/nthmp/Tauranga_harbour_Tohoku_tsunami/tauranga.f90
@@ -258,7 +258,7 @@ program Tauranga
 
     use global_mod, only: ip, dp, minimum_allowed_depth, default_nonlinear_timestepping_method
     use domain_mod, only: domain_type
-    use multidomain_mod, only: multidomain_type, setup_multidomain, test_multidomain_mod
+    use multidomain_mod, only: multidomain_type
     use boundary_mod, only: boundary_stage_transmissive_normal_momentum, flather_boundary, &
         boundary_stage_transmissive_momentum, boundary_stage_radiation_momentum
     use local_routines

--- a/propagation/SWALS/examples/parabolic_canal/parabolic_canal.f90
+++ b/propagation/SWALS/examples/parabolic_canal/parabolic_canal.f90
@@ -19,7 +19,7 @@ module local_routines
         !
         ! Initial conditions
         !
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
 
         integer(ip):: i,j
         real(dp):: x, y, cx, cy, initial_stage_1, initial_stage_2, radius
@@ -106,7 +106,7 @@ program parabolic_canal
 
     real(dp), parameter :: mesh_refine = 3.0_dp
 
-    real(dp), parameter, dimension(2):: global_ll = [0.0_dp, 30.0_dp] ! Latitude so we have Coriolis
+    real(dp), parameter :: global_ll(2) = [0.0_dp, 30.0_dp] ! Latitude so we have Coriolis
         ! lower-left corner coordinate
 
     ! A 'wide' setup in the NS direction. This performs poorly for the VH component -- perhaps because of
@@ -119,9 +119,9 @@ program parabolic_canal
     !    ! grid size (number of x/y cells)
 
     ! A 'narrow' setup in the NS direction.
-    real(dp), parameter, dimension(2):: global_lw = [0.10372884337_dp, 0.0044915764_dp]
+    real(dp), parameter :: global_lw(2) = [0.10372884337_dp, 0.0044915764_dp]
         ! length/width (10 km x 500 m @ 30 degrees latitude)
-    integer(ip), parameter, dimension(2):: global_nx = nint([200, 5]*mesh_refine) !
+    integer(ip), parameter :: global_nx(2) = nint([200, 5]*mesh_refine) !
         ! grid size (number of x/y cells)
 
     real(dp) :: non_adaptive_ts 

--- a/propagation/SWALS/examples/paraboloid_bowl/paraboloid_bowl.f90
+++ b/propagation/SWALS/examples/paraboloid_bowl/paraboloid_bowl.f90
@@ -11,7 +11,7 @@ module local_routines
     contains 
 
     subroutine set_initial_conditions_paraboloid_bowl(domain)            
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         integer(ip):: i, j
         real(dp) :: x, y, L, D, r0, r, A
 
@@ -86,15 +86,15 @@ program run_paraboloid_basin
     real(dp) ::  global_dt ! = (0.23_dp/mesh_refine) * 1.0_dp
 
     ! Approx timestep between outputs
-    real(dp) :: approximate_writeout_frequency = 1.0_dp
-    real(dp) :: final_time = 300.0_dp * 1.0_dp
+    real(dp), parameter :: approximate_writeout_frequency = 1.0_dp
+    real(dp), parameter :: final_time = 300.0_dp * 1.0_dp
 
     ! Length/width
-    real(dp), parameter, dimension(2):: global_lw = 8000.0_dp * [1.0_dp, 1.0_dp]
+    real(dp), parameter :: global_lw(2) = 8000.0_dp * [1.0_dp, 1.0_dp]
     ! Lower-left corner coordinate
-    real(dp), parameter, dimension(2):: global_ll = -global_lw/2.0_dp
+    real(dp), parameter :: global_ll(2) = -global_lw/2.0_dp
     ! grid size (number of x/y cells)
-    integer(ip), parameter, dimension(2):: global_nx = [100, 100]*mesh_refine + 1
+    integer(ip), parameter :: global_nx(2) = [100, 100]*mesh_refine + 1
 
     ! Useful misc variables
     integer(ip):: nd, j

--- a/propagation/SWALS/examples/periodic_convergence/model.f90
+++ b/propagation/SWALS/examples/periodic_convergence/model.f90
@@ -9,7 +9,7 @@ module local_routines
     contains 
 
     subroutine set_initial_conditions(domain)            
-        class(domain_type), intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         integer(ip):: i, j
         real(dp), allocatable:: x(:), y(:)
 
@@ -62,16 +62,16 @@ program periodic_convergence
     integer(ip) :: mesh_refine
 
     ! Approx timestep between outputs
-    real(dp) :: approximate_writeout_frequency = 0.005_dp
+    real(dp) :: approximate_writeout_frequency = 4.0e-04_dp
     real(dp) :: final_time = 0.06_dp
     real(dp) :: my_dt 
 
     ! Length/width
-    real(dp), parameter, dimension(2):: global_lw = [1.0_dp, 1.0_dp]
+    real(dp), parameter :: global_lw(2) = [1.0_dp, 1.0_dp]
     ! Lower-left corner coordinate
-    real(dp), parameter, dimension(2):: global_ll = [0.0_dp, 0.0_dp]
+    real(dp), parameter :: global_ll(2) = [0.0_dp, 0.0_dp]
     ! grid size (number of x/y cells)
-    integer(ip), dimension(2):: global_nx
+    integer(ip) :: global_nx(2)
 
     ! Number of domains in model; loop variable
     integer(ip):: nd, j
@@ -142,7 +142,9 @@ program periodic_convergence
     !
     do while (.true.)
 
-        call md%write_outputs_and_print_statistics(approximate_writeout_frequency = 4.0e-04_dp, timing_tol=my_dt/3.0_dp)
+        call md%write_outputs_and_print_statistics(&
+            approximate_writeout_frequency = approximate_writeout_frequency, &
+            timing_tol=my_dt/3.0_dp)
 
         if (md%domains(1)%time > final_time) exit
 

--- a/propagation/SWALS/examples/periodic_multidomain/model.f90
+++ b/propagation/SWALS/examples/periodic_multidomain/model.f90
@@ -13,7 +13,7 @@ module local_routines
     contains 
 
     subroutine set_initial_conditions(domain, stage_file, rise_time, global_dt)
-        class(domain_type), intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         character(len=charlen), intent(in) :: stage_file
         real(dp), intent(in) :: rise_time
         real(dp), intent(in) :: global_dt
@@ -172,12 +172,11 @@ program periodic_multidomain
     real(dp) :: final_time = 3600.0_dp * 24.0_dp
 
     ! Length/width
-    real(dp), parameter, dimension(2):: global_lw = [360.0_dp, 135.0_dp]
+    real(dp), parameter :: global_lw(2) = [360.0_dp, 135.0_dp]
     ! Lower-left corner coordinate
-    !real(dp), parameter, dimension(2):: global_ll = [-180.0_dp, -70.0_dp]
-    real(dp), parameter, dimension(2):: global_ll = [-40.0_dp, -70.0_dp]
+    real(dp), parameter :: global_ll(2) = [-40.0_dp, -70.0_dp]
     ! grid size (number of x/y cells)
-    integer(ip), parameter, dimension(2):: global_nx = nint(global_lw*15*mesh_refine)
+    integer(ip), parameter :: global_nx(2) = nint(global_lw*15*mesh_refine)
 
     ! Inner domain 
     integer(ip), parameter :: nest_ratio = 5_ip

--- a/propagation/SWALS/examples/radial_dam_break/radial_dam_break.f90
+++ b/propagation/SWALS/examples/radial_dam_break/radial_dam_break.f90
@@ -121,6 +121,8 @@ program radial_dam_break
         call set_initial_conditions_radial_dam(md%domains(j))
     end do
 
+    call md%make_initial_conditions_consistent
+
     ! Time-step at which we evolve the solution
     global_dt = 0.75_dp * md%stationary_timestep_max()
 

--- a/propagation/SWALS/examples/radial_dam_break/radial_dam_break.f90
+++ b/propagation/SWALS/examples/radial_dam_break/radial_dam_break.f90
@@ -12,7 +12,7 @@ module local_routines
         !
         ! This function sets the initial conditions in a domain
         !
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         integer(ip):: i,j
         real(dp):: x, y, cx, cy, initial_stage_1, initial_stage_2, radius
 
@@ -29,7 +29,7 @@ module local_routines
         domain%U(:,:,ELV) = 0._dp
         ! Wall boundaries (without boundary conditions)
         domain%U(1,:,ELV) = 20.0_dp
-        domain%U(domain%nx(1),:,4) = 20.0_dp
+        domain%U(domain%nx(1),:,ELV) = 20.0_dp
         domain%U(:,1,ELV) = 20.0_dp
         domain%U(:,domain%nx(2),ELV) = 20.0_dp
 
@@ -37,10 +37,10 @@ module local_routines
         domain%U(:,:,STG) = max(domain%U(:,:,STG), domain%U(:,:,ELV))
 
         ! Add a stage perturbation
-        cx = (domain%lw(1))*0.5
-        cy = (domain%lw(2))*0.5
-        do i = 1,domain%nx(1)
-            do j = 1, domain%nx(2)
+        cx = (domain%lw(1))*0.5_dp
+        cy = (domain%lw(2))*0.5_dp
+        do j = 1, domain%nx(2)
+            do i = 1,domain%nx(1)
                 ! Set perturbation based on distance to the centre
                 x = (i-0.5_dp)*domain%dx(1) - cx
                 y = (j-0.5_dp)*domain%dx(2) - cy 
@@ -79,11 +79,11 @@ program radial_dam_break
     real(dp), parameter :: final_time = 2.0_dp * 1
 
     ! length/width
-    real(dp), parameter, dimension(2):: global_lw = [400._dp, 400._dp] 
+    real(dp), parameter :: global_lw(2) = [400._dp, 400._dp] 
     ! lower-left corner coordinate
-    real(dp), parameter, dimension(2):: global_ll = [0._dp, 0._dp]
+    real(dp), parameter :: global_ll(2) = [0._dp, 0._dp]
     ! grid size (number of x/y cells)
-    integer(ip), parameter, dimension(2):: global_nx = [400, 400] * 2 + 1
+    integer(ip), parameter :: global_nx(2) = [400, 400] * 2 + 1
 
     ! Misc
     integer :: j, nd

--- a/propagation/SWALS/examples/spherical_box/model.f90
+++ b/propagation/SWALS/examples/spherical_box/model.f90
@@ -10,7 +10,7 @@ module local_routines
     contains 
 
     subroutine set_initial_conditions(domain, grid_smooth_iterations)            
-        class(domain_type), intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         integer(ip), intent(in) :: grid_smooth_iterations
 
         integer(ip):: j

--- a/propagation/SWALS/examples/uniform_channel/uniform_channel.f90
+++ b/propagation/SWALS/examples/uniform_channel/uniform_channel.f90
@@ -12,16 +12,16 @@ module local_routines
     contains 
 
     subroutine set_initial_conditions_uniform_channel(domain)            
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         integer(ip):: i,j
         real(dp):: x, y, cx, cy, slope
 
         ! Set elevation
         slope = bed_slope 
-        cx = (domain%lw(1))*0.5
-        cy = (domain%lw(2))*0.5
-        do i = 1,domain%nx(1)
-            do j = 1, domain%nx(2)
+        cx = (domain%lw(1))*0.5_dp
+        cy = (domain%lw(2))*0.5_dp
+        do j = 1, domain%nx(2)
+            do i = 1,domain%nx(1)
                 x = (i-0.5_dp)*domain%dx(1) - cx
                 y = (j-0.5_dp)*domain%dx(2) - cy 
                 domain%U(i,j,ELV) = y*slope

--- a/propagation/SWALS/examples/uniform_slope/uniform_slope.f90
+++ b/propagation/SWALS/examples/uniform_slope/uniform_slope.f90
@@ -12,17 +12,17 @@ module local_routines
     contains 
 
     subroutine set_initial_conditions_uniform_slope(domain)            
-        class(domain_type), target, intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         integer(ip):: i,j
         real(dp):: x, y, cx, cy, slope
 
         ! Set elevation
         slope = bed_slope 
 
-        cx = (domain%lw(1))*0.5
-        cy = (domain%lw(2))*0.5
-        do i = 1,domain%nx(1)
-            do j = 1, domain%nx(2)
+        cx = (domain%lw(1))*0.5_dp
+        cy = (domain%lw(2))*0.5_dp
+        do j = 1, domain%nx(2)
+            do i = 1,domain%nx(1)
                 x = (i-0.5_dp)*domain%dx(1) - cx
                 y = (j-0.5_dp)*domain%dx(2) - cy 
                 domain%U(i,j,ELV) = y*slope

--- a/propagation/SWALS/examples/uniform_slope_shallow/uniform_slope.f90
+++ b/propagation/SWALS/examples/uniform_slope_shallow/uniform_slope.f90
@@ -10,7 +10,7 @@ module local_routines
     contains 
 
     subroutine set_initial_conditions_uniform_slope(domain, bed_slope)
-        class(domain_type), intent(inout):: domain
+        type(domain_type), intent(inout):: domain
         real(dp), intent(in) :: bed_slope
         integer(ip):: i,j
         real(dp):: x, y, cx, cy, slope
@@ -18,10 +18,10 @@ module local_routines
         ! Set elevation
         slope = bed_slope 
 
-        cx = (domain%lw(1))*0.5
-        cy = (domain%lw(2))*0.5
-        do i = 1,domain%nx(1)
-            do j = 1, domain%nx(2)
+        cx = (domain%lw(1))*0.5_dp
+        cy = (domain%lw(2))*0.5_dp
+        do j = 1, domain%nx(2)
+            do i = 1,domain%nx(1)
                 x = (i-0.5_dp)*domain%dx(1) - cx
                 y = (j-0.5_dp)*domain%dx(2) - cy 
                 domain%U(i,j,ELV) = y*slope


### PR DESCRIPTION
Various improvements to the examples, such as using type(x) rather than class(x) if possible, removing unrequired 'target' statements, specify some missing real precisions.