### PR TITLE
Log fix

### DIFF
--- a/propagation/SWALS/src/shallow_water/domain_mod.f90
+++ b/propagation/SWALS/src/shallow_water/domain_mod.f90
@@ -687,7 +687,7 @@ TIMER_START("compute_statistics")
         maxstage = -HUGE(1.0_dp)
         maxspeed = 0.0_dp ! speed is always > 0
         minstage = HUGE(1.0_dp)
-        minspeed = HUGE(1.0_dp) ! speed is always > 0
+        minspeed = HUGE(1.0_dp)
 
         ! If we are using a 'truely-linear' solver then the depth is always recorded from MSL for certain
         ! calculations (pressure gradient term, and wetting/drying)
@@ -780,7 +780,7 @@ TIMER_START("compute_statistics")
                         ! The kinetic energy is integral of ( 1/2 depth speed^2)
                         domain%energy_kinetic_on_rho_work(j) = domain%energy_kinetic_on_rho_work(j) + &
                             real(domain%area_cell_y(j) * 0.5_dp * depth_C * speed_sq, force_double)
-                     end if
+                    end if
 
                     maxspeed = max(maxspeed, speed_sq) ! Will undo the sqrt later.
                     minspeed = min(minspeed, speed_sq) ! Will undo the sqrt later

--- a/propagation/SWALS/src/shallow_water/multidomain_mod.f90
+++ b/propagation/SWALS/src/shallow_water/multidomain_mod.f90
@@ -1940,13 +1940,24 @@ module multidomain_mod
     end subroutine
 
 
-    !
-    ! Convenience print routine
-    !
     subroutine print_multidomain(md, global_stats_only, energy_is_finite)
-        class(multidomain_type), intent(inout) :: md ! inout allows for timer to run
+        !! Print multidomain summary statistics. 
+        !! Statistics are computed using "priority domain" parts of each domain.
+        !! NOTE: It is **possible** (but probably unusual) for these statistics to be
+        !! inconsistent with the statistics stored in domain%max_U (and the netcdf files).
+        !! The reason is that max_U is computed after each domain time-step, but always
+        !! before parallel communication and flux correction. In contrast, this routine is
+        !! usually called just after parallel communication and flux correction. So for
+        !! example, if the stage (or max-speed) occurs in a region where flux-correction
+        !! was applied, the stage (or max-speed) will be different.
+        class(multidomain_type), intent(inout) :: md 
+            !! multidomain. This is inout to allow the timer to run
         logical, optional, intent(in) :: global_stats_only
+            !! If .true. then only print global multidomain statistics. By default (.FALSE.) print
+            !! statistics for every domain
         logical, optional, intent(out) :: energy_is_finite
+            !! Record whether the energy is finite. This can be useful to terminate models
+            !! that attain NaN energy.
 
         integer(ip) :: k
         real(dp) :: minstage, maxstage, minspeed, maxspeed, stg1, speed_sq, depth_C, depth_E, depth_N

--- a/propagation/SWALS/src/shallow_water/multidomain_mod.f90
+++ b/propagation/SWALS/src/shallow_water/multidomain_mod.f90
@@ -473,6 +473,8 @@ module multidomain_mod
         ! Swap max_U and domain%U, without using signifiant extra memory, one variable at a time
         do k = 1, n
             ! For each domain, copy the k'th variable in domain%max_U(:,:,k) into domain%U(:,:,1)
+            ! Don't try to pack multiple variables at once, to avoid possible
+            ! modification of UH/VH variables in domain_mod::receive_halos
             do j = 1, size(md%domains)
                 do j1 = 1, size(md%domains(j)%max_U, 2)
                     do i = 1, size(md%domains(j)%max_U, 1)

--- a/propagation/SWALS/src/shallow_water/multidomain_mod.f90
+++ b/propagation/SWALS/src/shallow_water/multidomain_mod.f90
@@ -1971,7 +1971,7 @@ module multidomain_mod
         global_max_stage = -HUGE(1.0_dp)
         global_min_stage = HUGE(1.0_dp)
         global_max_speed = 0.0_dp
-        global_min_speed = 0.0_dp
+        global_min_speed = HUGE(1.0_dp) !0.0_dp
         global_energy_potential_on_rho = 0.0_dp
         global_energy_kinetic_on_rho = 0.0_dp
         global_energy_total_on_rho = 0.0_dp


### PR DESCRIPTION
Minor edits related to log file statistics:
* Fix a bug that would prevent `global_min_speed` in the multidomain log file from exceeding zero, if there really is nonzero velocity everywhere.
* Improve comments, including the possibility of differences between the log statistics and results in domain%max_U and the netcdf grid outputs. 
  * The main issue is that the log-statistics are generally computed immediately AFTER flux correction has been applied, whereas the max_U statistics are updated after every domain step, but before parallel communication and flux correction. Arguably neither is more "correct", but there is potential for flux correction to change the max-stage (or max-speed) at the site of the correction, and if these are the domain-specific extremes they could show up in the log statistcs. 