### PR TITLE
updates to address warnings flagged by ifx compiler with -std08

### DIFF
--- a/propagation/SWALS/src/shallow_water/domain_mod.f90
+++ b/propagation/SWALS/src/shallow_water/domain_mod.f90
@@ -2535,7 +2535,7 @@ TIMER_STOP('write_gauge_time_series')
         ! satisfied.
         do i = 1, 10000
             inquire(i, opened = is_open)
-            if(is_open) call flush(i)
+            if(is_open) flush(i)
         end do
 
 #ifndef NONETCDF

--- a/propagation/SWALS/src/shallow_water/domain_mod_compute_fluxes_DE1_inner_include.f90
+++ b/propagation/SWALS/src/shallow_water/domain_mod_compute_fluxes_DE1_inner_include.f90
@@ -36,11 +36,11 @@
     real(force_double), parameter:: half_gravity = HALF_dp * gravity
     real(force_double):: bed_slope_pressure_s, bed_slope_pressure_n, bed_slope_pressure_e, bed_slope_pressure_w
     real(force_double) :: half_g_hh_edge, depth_pos, depth_pos_star, depth_pos_c, depth_neg, depth_neg_star, depth_neg_c
-    real(force_double):: denom, inv_denom, max_speed, max_dt, dx_cfl_half_inv(2), stg_b, stg_a
+    real(force_double):: denom, inv_denom, max_speed, max_dt, stg_b, stg_a
 
     ! convenience variables
     integer(ip):: i, j, nx, ny, jlast
-    real(dp):: half_cfl, max_dt_inv, dxb, common_multiple, fr2
+    real(dp):: half_cfl, max_dt_inv, dxb, common_multiple, fr2, dx_cfl_half_inv(2)
     real(dp):: diffusion_hll, diffusion_turbulent, diffusion_total, diffusion_max
     real(dp), parameter :: diffusion_scale = ONE_dp
     real(dp), parameter :: EPS = 1.0e-12_dp

--- a/propagation/SWALS/src/shallow_water/multidomain_mod.f90
+++ b/propagation/SWALS/src/shallow_water/multidomain_mod.f90
@@ -3788,7 +3788,7 @@ __FILE__
                 end do
             end do
 #ifdef COARRAY
-            call flush(log_output_unit)
+            flush(log_output_unit)
             call sync_all_generic
 #endif
             ! Here if it's working, the 'err' will depend on the precision.

--- a/propagation/SWALS/src/util/sort_index_template2.f90
+++ b/propagation/SWALS/src/util/sort_index_template2.f90
@@ -12,9 +12,9 @@
     !   out of the standard loop, and use dedicated coding.
     ! __________________________________________________________
     ! __________________________________________________________
+    integer(c_int), intent(in) :: n
     SORT_INDEX_TYPE , Intent (In) :: array(n)
     Integer(c_int), Intent (Out) :: inds(n)
-    integer(c_int), intent(in) :: n
     ! __________________________________________________________
     SORT_INDEX_TYPE2 :: XVALA, XVALB
     !

--- a/propagation/SWALS/src/util/stop_mod.f90
+++ b/propagation/SWALS/src/util/stop_mod.f90
@@ -17,12 +17,12 @@ module stop_mod
         ! A better but more complex approach would be to track open file units
         do i = -10000, 10000
             inquire(unit=i, opened=is_open_file_unit)
-            if(is_open_file_unit) call flush(i)
+            if(is_open_file_unit) flush(i)
         end do
 
         ! Make sure we do not miss the log output unit
         inquire(unit=log_output_unit, opened=is_open_file_unit)
-        if(is_open_file_unit) call flush(log_output_unit)
+        if(is_open_file_unit) flush(log_output_unit)
 
         ! Call the most relevant 'stop' command
 #ifdef COARRAY


### PR DESCRIPTION
Minor changes to address some warnings flagged by `ifx` with the option `-std08`. These relate to inconsequential uses of non-standard code (apparently widely supported, as I didn't detect these earlier).
* Replace `call flush( )` with just `flush`
* Swap argument declaration order in one subroutine so that `n` is declared before `array_size(n)`. 
* For cases compiled with `REALFLOAT`, avoid calling `max(a, b)` where `a,b` have different precisions.