### PR TITLE
updates for new NCI thredds server

### DIFF
--- a/R/examples/austptha_template/SOURCE_ZONES/TEMPLATE/TSUNAMI_EVENTS/sum_tsunami_unit_sources.R
+++ b/R/examples/austptha_template/SOURCE_ZONES/TEMPLATE/TSUNAMI_EVENTS/sum_tsunami_unit_sources.R
@@ -6,7 +6,7 @@
 ##  # I can access ncdf files via opendap. However, there is a strange bug that appears when indexing subsets.
 ##  
 ##  library(ncdf4)
-##  fid = nc_open('http://dapds00.nci.org.au/thredds/dodsC/fj6/PTHA/AustPTHA/v2017/SOURCE_ZONES/puysegur/TSUNAMI_UNIT_SOURCE/unit_source_tsunami/RUN_20161121104520_puysegur_1_1/RUN_ID100001_20161123_082248.005/Gauges_data_ID100001.nc')
+##  fid = nc_open('https://thredds.nci.org.au/thredds/dodsC/fj6/PTHA/AustPTHA/v2017/SOURCE_ZONES/puysegur/TSUNAMI_UNIT_SOURCE/unit_source_tsunami/RUN_20161121104520_puysegur_1_1/RUN_ID100001_20161123_082248.005/Gauges_data_ID100001.nc')
 ##  
 ##  # This works -- note that start[2] is not = 1 (start[2] corresponds to the tide gauge index)
 ##  stage = ncvar_get(fid, 'stage', start=c(1,2), count=c(-1,1))
@@ -14,7 +14,7 @@
 ##  # stage = ncvar_get(fid, 'stage', start=c(1,1), count=c(-1,1))
 ##  
 ##  # Further, ncks seems to HANG when retrieving the first tide gauge index
-##  ncks -d station,0 -v stage 'http://dapds00.nci.org.au/thredds/dodsC/fj6/PTHA/AustPTHA/v2017/SOURCE_ZONES/puysegur/TSUNAMI_UNIT_SOURCE/unit_source_tsunami/RUN_20161121104520_puysegur_1_1/RUN_ID100001_20161123_082248.005/Gauges_data_ID100001.nc'
+##  ncks -d station,0 -v stage 'https://thredds.nci.org.au/thredds/dodsC/fj6/PTHA/AustPTHA/v2017/SOURCE_ZONES/puysegur/TSUNAMI_UNIT_SOURCE/unit_source_tsunami/RUN_20161121104520_puysegur_1_1/RUN_ID100001_20161123_082248.005/Gauges_data_ID100001.nc'
 ##  # See this related bug!
 ##  https://sourceforge.net/p/nco/bugs/57/
 ##  # That link says it's only on netcdf version 4.1.3 -- that is the default ubuntu 14.04 version.

--- a/R/examples/okada_displacements_ptha18_scenarios/config.R
+++ b/R/examples/okada_displacements_ptha18_scenarios/config.R
@@ -22,7 +22,7 @@ output_base_dir = './OUTPUTS/'
 dir.create(output_base_dir, recursive=TRUE, showWarnings=FALSE)
 
 # Directory with sourcezone contours used in Australian PTHA. Accessed from here (zip-file): 
-#    http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalog/fj6/PTHA/AustPTHA_1/DATA/catalog.xml
+#    https://thredds.nci.org.au/thredds/catalog/fj6/PTHA/AustPTHA_1/DATA/catalog.xml
 SOURCEZONE_CONTOURS_BASEDIR = './inputs_from_ptha18/SOURCEZONE_CONTOURS/'
 # Directory with sourcezone downdip lines used in Australian PTHA. Accessed
 # from the same location as SOURCEZONE_CONTOURS_BASEDIR (above)

--- a/misc/probabilistic_inundation_tonga2020/sources/random/select_random_scenarios.R
+++ b/misc/probabilistic_inundation_tonga2020/sources/random/select_random_scenarios.R
@@ -50,7 +50,7 @@ if(!file.exists(compute_rates_session)){
 if(!file.exists(compute_rates_session)){
     # If the file wasn't found in the above locations, then download it locally
     compute_rates_session_download = 
-        'http://dapds00.nci.org.au/thredds/fileServer/fj6/PTHA/AustPTHA_1/EVENT_RATES/compute_rates_all_sources_session.RData'
+        'https://thredds.nci.org.au/thredds/fileServer/fj6/PTHA/AustPTHA_1/EVENT_RATES/compute_rates_all_sources_session.RData'
     download.file(compute_rates_session_download, compute_rates_session)
 }
 crs_data = new.env()

--- a/ptha_access/DETAILED_README.Rmd
+++ b/ptha_access/DETAILED_README.Rmd
@@ -1,6 +1,6 @@
 # **Obtaining detailed information on earthquake scenarios, tsunami initial conditions, and tsunami time-series**
 
-**Note to users -- a security update to the NCI THREDDS Server on 16/07/21 broke the codes here, and caused the tests to fail. On 21/07/21 we implemented changes suggested by NCI to work-around the issues. Users will need to update their copy of the codes here in order to use the database.**
+**Note to users -- the NCI THREDDS Server URL has changed, and the old URL will be decommissioned on June 30 2024. The codes have been updated to use the new URL. Users will need to update their copy of the code to continue using the database.**
 
 For every PTHA18 scenario we provide earthquake information, tsunami
 initial conditions, and tsunami time-series at every hazard point. Combined with

--- a/ptha_access/DETAILED_README.md
+++ b/ptha_access/DETAILED_README.md
@@ -1,6 +1,6 @@
 # **Obtaining detailed information on earthquake scenarios, tsunami initial conditions, and tsunami time-series**
 
-**Note to users -- a security update to the NCI THREDDS Server on 16/07/21 broke the codes here, and caused the tests to fail. On 21/07/21 we implemented changes suggested by NCI to work-around the issues. Users will need to update their copy of the codes here in order to use the database.**
+**Note to users -- the NCI THREDDS Server URL has changed, and the old URL will be decommissioned on June 30 2024. The codes have been updated to use the new URL. Users will need to update their copy of the code to continue using the database.**
 
 For every PTHA18 scenario we provide earthquake information, tsunami
 initial conditions, and tsunami time-series at every hazard point. Combined with

--- a/ptha_access/R/config.R
+++ b/ptha_access/R/config.R
@@ -69,10 +69,10 @@ if(file.exists('/g/data/fj6/PTHA/AustPTHA_1')){
     max_stringlength = '[stringlength=4096]'
     #
     .GDATA_OPENDAP_BASE_LOCATION = paste0(max_stringlength, 
-        'https://dapds00.nci.org.au/thredds/dodsC/fj6/PTHA/AustPTHA_1/')
+        'https://thredds.nci.org.au/thredds/dodsC/fj6/PTHA/AustPTHA_1/')
     #
     # Non-netcdf data -- this location only allows download
-    .GDATA_HTTP_BASE_LOCATION = 'https://dapds00.nci.org.au/thredds/fileServer/fj6/PTHA/AustPTHA_1/'
+    .GDATA_HTTP_BASE_LOCATION = 'https://thredds.nci.org.au/thredds/fileServer/fj6/PTHA/AustPTHA_1/'
 }
 
 #'

--- a/ptha_access/R/get_supporting_data.R
+++ b/ptha_access/R/get_supporting_data.R
@@ -6,7 +6,7 @@ if(!exists('config_env')){
     source('R/config.R', local=config_env)
 }
 
-#nci_thredds_source_zones_base = 'http://dapds00.nci.org.au/thredds/fileServer/fj6/PTHA/AustPTHA_1/SOURCE_ZONES/'
+#nci_thredds_source_zones_base = 'https://thredds.nci.org.au/thredds/fileServer/fj6/PTHA/AustPTHA_1/SOURCE_ZONES/'
 nci_thredds_source_zones_base = paste0(config_env$.GDATA_HTTP_BASE_LOCATION, 'SOURCE_ZONES/')
 
 install_base = getwd()

--- a/ptha_access/README.Rmd
+++ b/ptha_access/README.Rmd
@@ -1,6 +1,6 @@
 # **Guide to accessing the 2018 Australian Probabilistic Tsunami Hazard Assessment (PTHA18) results**
 
-**Note to users -- a security update to the NCI THREDDS Server around 16/07/21 broke the codes here and caused the tests to fail. On 21/07/21 we implemented changes suggested by NCI to work-around the issues. Users will need to update their copy of the codes here in order to use the database.**
+**Note to users -- the NCI THREDDS Server URL has changed, and the old URL will be decommissioned on June 30 2024. The codes have been updated to use the new URL. Users will need to update their copy of the code to continue using the database.**
 
 This guide explains how to access basic tsunami hazard information in easy-to-use csv and
 shapefile formats. 
@@ -90,7 +90,7 @@ It contains the following columns:
 * `lon`, `lat` give the hazard point location in longitude/latitude (degrees). 
 * `elev` is the bathymetry at the hazard point (negative = below MSL)
 * `gaugeID` is a hazard point ID (real number).
-* multiple columns with names like `STAGE_XXXX` where XXXX is a number, and 1/XXXX is the exceedance-rate. These corresponds to the tsunami maximum-stage which has mean exceedance-rate = 1/XXXX. For example, the column `STAGE_100` gives the tsunami maximum-stage that is exceeded once every 100 years on average, according to the mean of all the rate models in our logic-tree.
+* multiple columns with names like `STAGE_XXXX` where XXXX is a number, and 1/XXXX is the exceedance-rate. These corresponds to the tsunami maximum-stage which has mean exceedance-rate = 1/XXXX. For example, the column `STAGE_100` gives the tsunami maximum-stage that is exceeded once every 100 years on average, according to the mean of all the rate models in our logic-tree. The variable-rigidity earthquake model is assumed.
 * multiple columns with names like `STAGE_upper_ci_XXXX`. These values are similar to the above, but describe the upper limit of the 95% credible interval for the stage with the specified exceedance-rate. (i.e. 97.5 percentile)
 * multiple columns with names like `STAGE_lower_ci_XXXX`. These are similar to the above, but describe the lower limit of the 95% credible interval for the stage with the specified exceedance-rate. (i.e. 2.5 percentile)
 * multiple columns with names like `STAGE_median_XXXX`. These are similar to the above, but describe the 'epistemic median' stage with the specified exceedance-rate (i.e. 50th percentile)
@@ -100,6 +100,8 @@ It contains the following columns:
 Note 'max stage' values below 2cm (or above 20m) are treated as missing data
 (NA). Such values are unlikely to be of interest, but if necessary they can be
 reconstructed from the [detailed information](DETAILED_README.md).
+The latter also shows how to access exceedance-rates for the "constant rigidity
+model" (rather than the "variable rigidity model" used for the above CSV file).
 
 [Similar data is available in shapefile format here](https://dapds00.nci.org.au/thredds/fileServer/fj6/PTHA/AustPTHA_1/EVENT_RATES/revised1_tsunami_stages_at_fixed_return_periods.zip). You must unzip the file after download.
 Shapefiles have a weakness; attribute names must not exceed 10 characters. 

--- a/ptha_access/README.md
+++ b/ptha_access/README.md
@@ -1,6 +1,6 @@
 # **Guide to accessing the 2018 Australian Probabilistic Tsunami Hazard Assessment (PTHA18) results**
 
-**Note to users -- a security update to the NCI THREDDS Server around 16/07/21 broke the codes here and caused the tests to fail. On 21/07/21 we implemented changes suggested by NCI to work-around the issues. Users will need to update their copy of the codes here in order to use the database.**
+**Note to users -- the NCI THREDDS Server URL has changed, and the old URL will be decommissioned on June 30 2024. The codes have been updated to use the new URL. Users will need to update their copy of the code to continue using the database.**
 
 This guide explains how to access basic tsunami hazard information in easy-to-use csv and
 shapefile formats. 
@@ -99,8 +99,8 @@ It contains the following columns:
 
 Note 'max stage' values below 2cm (or above 20m) are treated as missing data
 (NA). Such values are unlikely to be of interest, but if necessary they can be
-reconstructed from the [detailed information](DETAILED_README.md). The latter
-also shows how to access exceedance-rates for the "constant rigidity
+reconstructed from the [detailed information](DETAILED_README.md).
+The latter also shows how to access exceedance-rates for the "constant rigidity
 model" (rather than the "variable rigidity model" used for the above CSV file).
 
 [Similar data is available in shapefile format here](https://dapds00.nci.org.au/thredds/fileServer/fj6/PTHA/AustPTHA_1/EVENT_RATES/revised1_tsunami_stages_at_fixed_return_periods.zip). You must unzip the file after download.

--- a/ptha_access/example_event_access_scripts/gauge_and_deformation_plots/plot_parameters.R
+++ b/ptha_access/example_event_access_scripts/gauge_and_deformation_plots/plot_parameters.R
@@ -16,14 +16,14 @@ source('./find_unit_sources_near_hypocentre.R')
 source_zone = 'kermadectonga2'
 # The PTHA18 unit-sources shapefile. This can be downloaded from the NCI
 # THREDDS SERVER. The location is like this (using the example of alaskaaleutians -- other sources are analogous):
-# http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalog/fj6/PTHA/AustPTHA_1/SOURCE_ZONES/alaskaaleutians/EQ_SOURCE/unit_source_grid/catalog.xml
+# https://thredds.nci.org.au/thredds/catalog/fj6/PTHA/AustPTHA_1/SOURCE_ZONES/alaskaaleutians/EQ_SOURCE/unit_source_grid/catalog.xml
 unit_source_polygon_shapefile = 
     '../../../../CODE/ptha/ptha_access/SOURCE_ZONES/kermadectonga2/EQ_SOURCE/unit_source_grid/kermadectonga2.shp'
 # Files with earthquake events for stochastic/variable-uniform/uniform slip, and the unit-source statistics
 # Download these from the NCI THREDDS SERVER and place in the current
 # directory (or edit the file name to include its full path). The download
 # location is like this (for alaskaaleutians -- other sources are analogous):
-# http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalog/fj6/PTHA/AustPTHA_1/SOURCE_ZONES/alaskaaleutians/TSUNAMI_EVENTS/catalog.xml
+# https://thredds.nci.org.au/thredds/catalog/fj6/PTHA/AustPTHA_1/SOURCE_ZONES/alaskaaleutians/TSUNAMI_EVENTS/catalog.xml
 stochastic_slip_events = 'all_stochastic_slip_earthquake_events_kermadectonga2.nc' 
 uniform_slip_events = 'all_uniform_slip_earthquake_events_kermadectonga2.nc' 
 variable_uniform_slip_events = 'all_variable_uniform_slip_earthquake_events_kermadectonga2.nc' 

--- a/ptha_access/get_detailed_PTHA18_source_zone_info.R
+++ b/ptha_access/get_detailed_PTHA18_source_zone_info.R
@@ -34,7 +34,7 @@ if(!file.exists(compute_rates_session)){
 }
 if(!file.exists(compute_rates_session)){
     # If the file wasn't found in the above locations, then download it locally
-    compute_rates_session_download = paste0('https://dapds00.nci.org.au/',
+    compute_rates_session_download = paste0('https://thredds.nci.org.au/',
         'thredds/fileServer/fj6/PTHA/AustPTHA_1/EVENT_RATES/',
         'compute_rates_all_sources_session.RData')
     download.file(compute_rates_session_download, compute_rates_session)


### PR DESCRIPTION
This changes the THREDDS URL prefix to keep working following updates to the NCI THREDDS Server.