### PR TITLE
Max stage dry cells

### DIFF
--- a/propagation/SWALS/examples/merewether/merewether_example.f90
+++ b/propagation/SWALS/examples/merewether/merewether_example.f90
@@ -190,6 +190,7 @@ program merewether
     md%domains(1)%nx = global_nx
     md%domains(1)%lower_left = global_ll
     md%domains(1)%timestepping_method = default_nonlinear_timestepping_method
+    !md%domains(1)%stage_extrema_include_dry_cells = .false.
 
     ! Initialise the domain
     call md%setup()

--- a/propagation/SWALS/src/shallow_water/domain_mod.f90
+++ b/propagation/SWALS/src/shallow_water/domain_mod.f90
@@ -399,6 +399,10 @@ module domain_mod
         real(dp) :: arrival_stage_threshold_above_msl_linear = 0.01_dp
             !! The "arrival time" is defined as the time at which the stage exceeds
             !! (msl_linear + arrival_stage_threshold_above_msl_linear) AND the cell is wet
+        logical :: max_stage_includes_dry_cells = .true.
+            !! If .TRUE. then max stage can be a 'dry cell' value (i.e. where the stage is the elevation).
+            !! If .FALSE. then we only update the max stage if the cell has depth > minimum_allowed_depth.
+            !! The difference can be substantive in models which have time-varying elevation.
         type(point_gauge_type) :: point_gauges
             !! Type to manage storing of tide gauges
 
@@ -2191,7 +2195,9 @@ EVOLVE_TIMER_START('update_max_quantities')
                         !$OMP DO SCHEDULE(STATIC)
                         do j = domain%yL, domain%yU !1, domain%nx(2)
                             do i = domain%xL, domain%xU !1, domain%nx(1)
-                                if(domain%U(i,j,STG) > domain%max_U(i,j,k)) then
+                                if( (domain%U(i,j,STG) > domain%max_U(i,j,k)) .and. &
+                                    ( domain%max_stage_includes_dry_cells .or. &
+                                      (domain%U(i,j,STG) > domain%U(i,j,ELV) + minimum_allowed_depth))) then
                                     domain%max_U(i,j,k) = domain%U(i,j,STG)
                                     domain%max_U(i,j,toms) = domain%time
                                 end if
@@ -2203,7 +2209,10 @@ EVOLVE_TIMER_START('update_max_quantities')
                         !$OMP DO SCHEDULE(STATIC)
                         do j = domain%yL, domain%yU !1, domain%nx(2)
                             do i = domain%xL, domain%xU !1, domain%nx(1)
-                                domain%max_U(i,j,k) = max(domain%max_U(i,j,k), domain%U(i,j,STG))
+                                if( domain%max_stage_includes_dry_cells .or. &
+                                    (domain%U(i,j,STG) > domain%U(i,j,ELV) + minimum_allowed_depth)) then
+                                    domain%max_U(i,j,k) = max(domain%max_U(i,j,k), domain%U(i,j,STG))
+                                end if
                             end do
                         end do
                         !$OMP END DO NOWAIT


### PR DESCRIPTION
When tracking min-stage and max-stage, by default SWALS does not consider whether a cell is wet or dry. However, in situations with time-varying topography (e.g. earthquakes with finite rise time), this will cause areas that are subsiding over time to record a max-stage that is higher than the final topography. 

This can be inconvenient to work with, so this PR introduces a new member of the domain type `domain%stage_extrema_include_dry_cells = .true.` . The default value preserves the old behaviour, while `.FALSE.` means that max-stage and min-stage are not updated in cells where the depth is below `minimum_allowed_depth` (corresponding to cells that SWALS treats as dry, with zero flow).

This means that in models with time-varying topography, we can prevent the issue mentioned above. 